### PR TITLE
Enumerate quorums method

### DIFF
--- a/stellarobservatory/quorum.py
+++ b/stellarobservatory/quorum.py
@@ -60,14 +60,6 @@ def generate_quorum_slices(quorum_set_definition, mode='economic'):
     return [frozenset(chain(*quorum_slice_product))
             for quorum_slice_product in quorum_slice_products]
 
-def is_quorum(quorum_slices_by_public_key, quorum_candidate):
-    """Given quorum slices, determine whether a quorum candidate is a quorum"""
-    return all([
-        any(quorum_slice.issubset(quorum_candidate)
-            for quorum_slice in quorum_slices_by_public_key[public_key])
-        for public_key in quorum_candidate
-    ])
-
 def quorum_intersection(quorums):
     """Returns whether the quorums have intersection, which intersect, and which do not"""
     intersecting_quorums = []

--- a/stellarobservatory/quorum_lachowski.py
+++ b/stellarobservatory/quorum_lachowski.py
@@ -167,7 +167,7 @@ def enumerate_quorums(slices_by_node):
         'deps_by_node': deps_by_node,
         'slices_by_node': slices_by_node
     }
-    all_nodes = slices_by_node.keys() # all nodes need to be present as keys here
+    all_nodes = set(slices_by_node.keys()) # all nodes need to be present as keys here
     traverse_quorums(fbas_info, set(), all_nodes)
 
 
@@ -177,7 +177,7 @@ def traverse_quorums(fbas_info, committed, remaining):
     enumerate all quorums Q of F with committed ⊆ Q ⊆ committed ∪ remaining"""
     if remaining == set():
         if is_quorum(fbas_info['slices_by_node'], committed):
-            print(committed)
+            logging.debug("found quorum: %s", committed)
     else:
         perimeter = committed.union(remaining)
         greatest_q = greatest_quorum(perimeter, fbas_info['slices_by_node'])

--- a/stellarobservatory/quorum_lachowski.py
+++ b/stellarobservatory/quorum_lachowski.py
@@ -26,10 +26,10 @@ def has_quorum_intersection(slices_by_node):
     # make sure only one SCC contains all minimal quorums
     non_intersection_quorums_counter = 0
     for component in sccs:
-        contains_quorum = len(contract_to_maximal_quorum(component, slices_by_node)) != 0
+        contains_slice = len(greatest_quorum(component, slices_by_node)) != 0
         logging.debug("SCC: %s contains a quorum: %s", component,
-                      contract_to_maximal_quorum(component, slices_by_node))
-        if contains_quorum:
+                      greatest_quorum(component, slices_by_node))
+        if contains_slice:
             non_intersection_quorums_counter += 1
 
     if non_intersection_quorums_counter != 1:
@@ -38,7 +38,7 @@ def has_quorum_intersection(slices_by_node):
 
     max_scc = sccs[0]
     logging.debug("max scc: %s", max_scc)
-    max_scc_max_quorum = contract_to_maximal_quorum(max_scc, slices_by_node)
+    max_scc_max_quorum = greatest_quorum(max_scc, slices_by_node)
     if not max_scc_max_quorum:
         logging.debug("No quorum found in transitive closure.")
         return False
@@ -66,7 +66,7 @@ def all_min_quorums_intersect(committed, remaining, max_commit_size, fbas_info):
     if len(committed) > max_commit_size:
         return True
 
-    committed_quorum = contract_to_maximal_quorum(committed, slices_by_node)
+    committed_quorum = greatest_quorum(committed, slices_by_node)
     if committed_quorum != set():
         return not (is_minimal_quorum(committed_quorum, slices_by_node) and \
                 has_disjoint_quorum(committed_quorum, max_scc, slices_by_node))
@@ -75,7 +75,7 @@ def all_min_quorums_intersect(committed, remaining, max_commit_size, fbas_info):
         return True
 
     perimeter = committed.union(remaining)
-    extension_quorum = contract_to_maximal_quorum(perimeter, slices_by_node)
+    extension_quorum = greatest_quorum(perimeter, slices_by_node)
     if extension_quorum != set():
         if not committed.issubset(extension_quorum):
             return True
@@ -92,23 +92,23 @@ def all_min_quorums_intersect(committed, remaining, max_commit_size, fbas_info):
         all_min_quorums_intersect(committed.union({split_node}), remaining_without_split,
                                   max_commit_size, fbas_info)
 
-def is_quorum(nodes, slices_by_node):
-    """Test whether the given nodes are a quorum"""
-    return contract_to_maximal_quorum(nodes, slices_by_node) != set()
+def contracts_to_greatest_quorum(nodes, slices_by_node):
+    """Check whether the given nodes contracts to a quorum."""
+    return greatest_quorum(nodes, slices_by_node) != set()
 
 def has_disjoint_quorum(nodes, max_scc, slices_by_node):
     """Test if there is a quorum disjoint from nodes (with max scc given)"""
-    return is_quorum(max_scc.difference(nodes), slices_by_node)
+    return contracts_to_greatest_quorum(max_scc.difference(nodes), slices_by_node)
 
 def is_minimal_quorum(nodes, slices_by_node):
     """Test if a contracted to maximal quorum is minimal"""
     for node in nodes:
         test_nodes = nodes.difference({node})
-        if contract_to_maximal_quorum(test_nodes, slices_by_node) != set():
+        if greatest_quorum(test_nodes, slices_by_node) != set():
             return False
     return True
 
-def contract_to_maximal_quorum(nodes, slices_by_node):
+def greatest_quorum(nodes, slices_by_node):
     """Contract nodes to a maximal quorum.
 
     Find greatest fixpoint of f(X) = {n ∈ X | containsQuorumSliceForNode(X, n)}.
@@ -122,15 +122,17 @@ def contract_to_maximal_quorum(nodes, slices_by_node):
     while True:
         filtered = set()
         for node in nodes:
-            if contains_quorum_slice(nodes, slices_by_node, node):
+            if contains_slice(nodes, slices_by_node, node):
                 filtered.add(node)
         if filtered in (nodes, {}):
             return filtered
         nodes = filtered
 
-def contains_quorum_slice(nodes_subset, slices, node):
-    """Check if for the given nodes and quorum slices there is a quorum slice
-    contained in the set of given nodes."""
+def contains_slice(nodes_subset, slices, node):
+    """Check if for the given node quorum slices there is a quorum slice
+    contained in the subset of nodes.
+    Input: FBAS(V,S) implicitly passed in via slices; nodes_subset ⊆ V; node ∈ V
+    Output: whether node has a quorum slice contained in nodes_subset"""
     return any(quorum_slice.issubset(nodes_subset) for quorum_slice in slices[node])
 
 def next_split_node(nodes_subset, deps_by_node):

--- a/stellarobservatory/quorum_lachowski.py
+++ b/stellarobservatory/quorum_lachowski.py
@@ -168,7 +168,7 @@ def enumerate_quorums(slices_by_node):
         'slices_by_node': slices_by_node
     }
     all_nodes = set(slices_by_node.keys()) # all nodes need to be present as keys here
-    traverse_quorums(fbas_info, set(), all_nodes)
+    return traverse_quorums(fbas_info, set(), all_nodes)
 
 
 def traverse_quorums(fbas_info, committed, remaining):
@@ -178,6 +178,7 @@ def traverse_quorums(fbas_info, committed, remaining):
     if remaining == set():
         if is_quorum(fbas_info['slices_by_node'], committed):
             logging.debug("found quorum: %s", committed)
+            yield frozenset(committed)
     else:
         perimeter = committed.union(remaining)
         greatest_q = greatest_quorum(perimeter, fbas_info['slices_by_node'])
@@ -186,5 +187,5 @@ def traverse_quorums(fbas_info, committed, remaining):
         # v ← pick from R:
         split = next_split_node(remaining, fbas_info['deps_by_node'])
         remaining_without_split = remaining.difference({split})
-        traverse_quorums(fbas_info, committed, remaining_without_split)
-        traverse_quorums(fbas_info, committed.union({split}), remaining_without_split)
+        yield from traverse_quorums(fbas_info, committed, remaining_without_split)
+        yield from traverse_quorums(fbas_info, committed.union({split}), remaining_without_split)

--- a/stellarobservatory/quorum_lachowski.py
+++ b/stellarobservatory/quorum_lachowski.py
@@ -135,22 +135,22 @@ def greatest_quorum(nodes, slices_by_node):
         nodes = filtered
 
 
-def is_quorum(slices, nodes_subset):
+def is_quorum(slices_by_node, nodes_subset):
     """
     Check whether nodes_subset is a quorum in FBAS F (implicitly passed in via slices).
     """
     return all([
-        contains_slice(nodes_subset, slices, v)
+        contains_slice(nodes_subset, slices_by_node, v)
         for v in nodes_subset
     ])
 
 
-def contains_slice(nodes_subset, slices, node):
+def contains_slice(nodes_subset, slices_by_node, node):
     """Check if for the given node quorum slices there is a quorum slice
     contained in the subset of nodes.
     Input: FBAS(V,S) implicitly passed in via slices; nodes_subset ⊆ V; node ∈ V
     Output: whether node has a quorum slice contained in nodes_subset"""
-    return any(quorum_slice.issubset(nodes_subset) for quorum_slice in slices[node])
+    return any(quorum_slice.issubset(nodes_subset) for quorum_slice in slices_by_node[node])
 
 
 def next_split_node(nodes_subset, deps_by_node):

--- a/stellarobservatory/quorum_lachowski.py
+++ b/stellarobservatory/quorum_lachowski.py
@@ -135,7 +135,7 @@ def greatest_quorum(nodes, slices_by_node):
         nodes = filtered
 
 
-def is_quorum(nodes_subset, slices):
+def is_quorum(slices, nodes_subset):
     """
     Check whether nodes_subset is a quorum in FBAS F (implicitly passed in via slices).
     """
@@ -158,3 +158,33 @@ def next_split_node(nodes_subset, deps_by_node):
     induced_subgraph = graph.get_induced_subgraph(deps_by_node, nodes_subset)
     indegrees = graph.get_indegrees(induced_subgraph)
     return max(indegrees.items(), key=operator.itemgetter(1))[0]
+
+
+def enumerate_quorums(slices_by_node):
+    """Enumerate all quorums of FBAS F (given by slices_by_node)."""
+    deps_by_node = get_dependencies_by_node(slices_by_node)
+    fbas_info = {
+        'deps_by_node': deps_by_node,
+        'slices_by_node': slices_by_node
+    }
+    all_nodes = slices_by_node.keys() # all nodes need to be present as keys here
+    traverse_quorums(fbas_info, set(), all_nodes)
+
+
+def traverse_quorums(fbas_info, committed, remaining):
+    """Given a FBAS F (by fbas_info) with set of nodes V
+    and given the sets: committed ⊆ V; R ⊆ V\\committed,
+    enumerate all quorums Q of F with committed ⊆ Q ⊆ committed ∪ remaining"""
+    if remaining == set():
+        if is_quorum(fbas_info['slices_by_node'], committed):
+            print(committed)
+    else:
+        perimeter = committed.union(remaining)
+        greatest_q = greatest_quorum(perimeter, fbas_info['slices_by_node'])
+        if greatest_q == set() or not committed.issubset(greatest_q):
+            return
+        # v ← pick from R:
+        split = next_split_node(remaining, fbas_info['deps_by_node'])
+        remaining_without_split = remaining.difference({split})
+        traverse_quorums(fbas_info, committed, remaining_without_split)
+        traverse_quorums(fbas_info, committed.union({split}), remaining_without_split)

--- a/stellarobservatory/quorum_lachowski_test.py
+++ b/stellarobservatory/quorum_lachowski_test.py
@@ -1,5 +1,5 @@
 """Test for Lachowski's quorum intersection function"""
-from .quorum_lachowski import greatest_quorum, has_quorum_intersection
+from .quorum_lachowski import greatest_quorum, has_quorum_intersection, is_quorum
 
 def test_greatest_quorum():
     """Test greatest_quorum()"""
@@ -71,3 +71,13 @@ def test_has_quorum_intersection_true_sccs():
         5: [{2, 5}]
     }
     assert has_quorum_intersection(slices_by_node) is True
+
+def test_is_quorum():
+    """Test is_quorum()"""
+    slices_by_node = {
+        1: [{1, 2}, {1, 3}, {1, 2, 3}],
+        2: [{1, 2}, {1, 4}],
+        3: [{1, 2, 3, 4}]
+    }
+    assert is_quorum({1, 2}, slices_by_node,) is True
+    assert is_quorum({1, 2, 3}, slices_by_node) is False

--- a/stellarobservatory/quorum_lachowski_test.py
+++ b/stellarobservatory/quorum_lachowski_test.py
@@ -1,5 +1,5 @@
 """Test for Lachowski's quorum intersection function"""
-from .quorum_lachowski import greatest_quorum, has_quorum_intersection, is_quorum
+from .quorum_lachowski import greatest_quorum, has_quorum_intersection, is_quorum, enumerate_quorums
 
 def test_greatest_quorum():
     """Test greatest_quorum()"""
@@ -81,3 +81,18 @@ def test_is_quorum():
     }
     assert is_quorum(slices_by_node, {1, 2}) is True
     assert is_quorum(slices_by_node, {1, 2, 3}) is False
+
+
+def test_enumerate_quorums():
+    """Test enumerate_quorums()"""
+    slices_by_node = {
+        1: [{1, 2, 3, 7}],
+        2: [{1, 2, 3, 7}],
+        3: [{1, 2, 3, 7}],
+        4: [{4, 5, 6, 7}],
+        5: [{4, 5, 6, 7}],
+        6: [{4, 5, 6, 7}],
+        7: [{7}],
+    }
+
+    enumerate_quorums(slices_by_node)

--- a/stellarobservatory/quorum_lachowski_test.py
+++ b/stellarobservatory/quorum_lachowski_test.py
@@ -1,8 +1,8 @@
 """Test for Lachowski's quorum intersection function"""
-from .quorum_lachowski import contract_to_maximal_quorum, has_quorum_intersection
+from .quorum_lachowski import greatest_quorum, has_quorum_intersection
 
-def test_contract_to_maximal_quorum():
-    """Test contract_to_maximal_quorum()"""
+def test_greatest_quorum():
+    """Test greatest_quorum()"""
     # pylint: disable=duplicate-code
     quorum_slices_by_public_key = {
         'A': [{'A', 'B'}, {'A', 'C'}, {'A', 'B', 'C'}],
@@ -10,14 +10,14 @@ def test_contract_to_maximal_quorum():
         'C': [{'A', 'B', 'C', 'D'}]
     }
     # Quorum (gets contracted):
-    assert contract_to_maximal_quorum({'A', 'B', 'C'}, quorum_slices_by_public_key) == {'A', 'B'}
+    assert greatest_quorum({'A', 'B', 'C'}, quorum_slices_by_public_key) == {'A', 'B'}
     # Quorum (already maximal):
-    assert contract_to_maximal_quorum({'A', 'B'}, quorum_slices_by_public_key) == {'A', 'B'}
+    assert greatest_quorum({'A', 'B'}, quorum_slices_by_public_key) == {'A', 'B'}
     # No quorum:
-    assert contract_to_maximal_quorum({'B', 'C'}, quorum_slices_by_public_key) == set()
-    assert contract_to_maximal_quorum({'A'}, quorum_slices_by_public_key) == set()
-    assert contract_to_maximal_quorum({'B'}, quorum_slices_by_public_key) == set()
-    assert contract_to_maximal_quorum({'C'}, quorum_slices_by_public_key) == set()
+    assert greatest_quorum({'B', 'C'}, quorum_slices_by_public_key) == set()
+    assert greatest_quorum({'A'}, quorum_slices_by_public_key) == set()
+    assert greatest_quorum({'B'}, quorum_slices_by_public_key) == set()
+    assert greatest_quorum({'C'}, quorum_slices_by_public_key) == set()
 
 def test_has_quorum_intersection_false():
     """Test failing has_quorum_intersection()"""

--- a/stellarobservatory/quorum_lachowski_test.py
+++ b/stellarobservatory/quorum_lachowski_test.py
@@ -79,5 +79,5 @@ def test_is_quorum():
         2: [{1, 2}, {1, 4}],
         3: [{1, 2, 3, 4}]
     }
-    assert is_quorum({1, 2}, slices_by_node,) is True
-    assert is_quorum({1, 2, 3}, slices_by_node) is False
+    assert is_quorum(slices_by_node, {1, 2}) is True
+    assert is_quorum(slices_by_node, {1, 2, 3}) is False

--- a/stellarobservatory/quorum_lachowski_test.py
+++ b/stellarobservatory/quorum_lachowski_test.py
@@ -19,6 +19,7 @@ def test_greatest_quorum():
     assert greatest_quorum({'B'}, quorum_slices_by_public_key) == set()
     assert greatest_quorum({'C'}, quorum_slices_by_public_key) == set()
 
+
 def test_has_quorum_intersection_false():
     """Test failing has_quorum_intersection()"""
     # Basically two disjoint quorums {A, B} and {D} (two SCCs)
@@ -31,6 +32,7 @@ def test_has_quorum_intersection_false():
 
     assert has_quorum_intersection(quorum_slices_by_node) is False
 
+
 def test_has_quorum_intersection_false_in_scc():
     """Test has_quorum_intersection() without intersection inside an scc"""
     slices_by_node = {
@@ -41,6 +43,7 @@ def test_has_quorum_intersection_false_in_scc():
     }
     assert has_quorum_intersection(slices_by_node) is False
 
+
 def test_has_quorum_intersection_false_two_max_scc():
     """Test has_quorum_intersection() without intersection with two max scc"""
     slices_by_node = {
@@ -49,6 +52,7 @@ def test_has_quorum_intersection_false_two_max_scc():
         3: [{3}]
     }
     assert has_quorum_intersection(slices_by_node) is False
+
 
 def test_has_quorum_intersection_true():
     """Test has_quorum_intersection()"""
@@ -61,6 +65,7 @@ def test_has_quorum_intersection_true():
 
     assert has_quorum_intersection(quorum_slices_by_node) is True
 
+
 def test_has_quorum_intersection_true_sccs():
     """Test has_quorum_intersection() with intersection with three sccs"""
     slices_by_node = {
@@ -71,6 +76,7 @@ def test_has_quorum_intersection_true_sccs():
         5: [{2, 5}]
     }
     assert has_quorum_intersection(slices_by_node) is True
+
 
 def test_is_quorum():
     """Test is_quorum()"""
@@ -94,5 +100,10 @@ def test_enumerate_quorums():
         6: [{4, 5, 6, 7}],
         7: [{7}],
     }
-
-    enumerate_quorums(slices_by_node)
+    quorums = list(enumerate_quorums(slices_by_node))
+    assert set(quorums) == set(
+        [frozenset({7}),
+         frozenset({4, 5, 6, 7}),
+         frozenset({1, 2, 3, 7}),
+         frozenset({1, 2, 3, 4, 5, 6, 7})]
+    )

--- a/stellarobservatory/quorum_test.py
+++ b/stellarobservatory/quorum_test.py
@@ -2,7 +2,7 @@
 import pytest
 from .utils.sets import deepfreezesets
 from .quorum import remove_from_qset_definition, get_normalized_qset_definition, \
-    get_minimal_quorum_intersection, generate_quorum_slices, is_quorum, quorum_intersection
+    get_minimal_quorum_intersection, generate_quorum_slices, quorum_intersection
 
 QSET_DEFINITION = {'threshold': 2, 'validators': ['A', 'B', 'C'], 'innerQuorumSets': []}
 QSET_DEFINITION_WITHOUT_B = {'threshold': 1, 'validators': ['A', 'C'], 'innerQuorumSets': []}
@@ -44,16 +44,6 @@ def test_qslice_generation():
     expected_sets_full.add(frozenset(['A', 'B', 'C']))
     result_full = generate_quorum_slices(QSET_DEFINITION, mode='full')
     assert deepfreezesets(result_full) == expected_sets_full
-
-def test_is_quorum():
-    """Test is_quorum()"""
-    quorum_slices_by_public_key = {
-        'A': [{'A', 'B'}, {'A', 'C'}, {'A', 'B', 'C'}],
-        'B': [{'A', 'B'}, {'A', 'D'}],
-        'C': [{'A', 'B', 'C', 'D'}]
-    }
-    assert is_quorum(quorum_slices_by_public_key, {'A', 'B'}) is True
-    assert is_quorum(quorum_slices_by_public_key, {'A', 'B', 'C'}) is False
 
 def test_quorum_intersection():
     """Test quorum_intersection()"""


### PR DESCRIPTION
Add enumerate quorums method and rename some methods:
- `contract_to_maximal_quorum` -> `greatest_quorum`
- prev. `is_quorum` -> `contracts_to_greatest_quorum` (used in current lachowski impl)
 
Add new methods:
- `enumerate_quorums`
- `is_quorum`
- `contains_slice`
- `traverse_quorums`

Add test for `enumerate_quorums`, move test for `is_quorum` and delete old `is_quorum` method.