### PR TITLE
Implement Torsten's quorum enumeration algo

### DIFF
--- a/stellarobservatory/quorum_lachowski.py
+++ b/stellarobservatory/quorum_lachowski.py
@@ -158,34 +158,3 @@ def next_split_node(nodes_subset, deps_by_node):
     induced_subgraph = graph.get_induced_subgraph(deps_by_node, nodes_subset)
     indegrees = graph.get_indegrees(induced_subgraph)
     return max(indegrees.items(), key=operator.itemgetter(1))[0]
-
-
-def enumerate_quorums(slices_by_node):
-    """Enumerate all quorums of FBAS F (given by slices_by_node)."""
-    deps_by_node = get_dependencies_by_node(slices_by_node)
-    fbas_info = {
-        'deps_by_node': deps_by_node,
-        'slices_by_node': slices_by_node
-    }
-    all_nodes = set(slices_by_node.keys()) # all nodes need to be present as keys here
-    return traverse_quorums(fbas_info, set(), all_nodes)
-
-
-def traverse_quorums(fbas_info, committed, remaining):
-    """Given a FBAS F (by fbas_info) with set of nodes V
-    and given the sets: committed ⊆ V; R ⊆ V\\committed,
-    enumerate all quorums Q of F with committed ⊆ Q ⊆ committed ∪ remaining"""
-    if remaining == set():
-        if is_quorum(fbas_info['slices_by_node'], committed):
-            logging.debug("found quorum: %s", committed)
-            yield frozenset(committed)
-    else:
-        perimeter = committed.union(remaining)
-        greatest_q = greatest_quorum(perimeter, fbas_info['slices_by_node'])
-        if greatest_q == set() or not committed.issubset(greatest_q):
-            return
-        # v ← pick from R:
-        split = next_split_node(remaining, fbas_info['deps_by_node'])
-        remaining_without_split = remaining.difference({split})
-        yield from traverse_quorums(fbas_info, committed, remaining_without_split)
-        yield from traverse_quorums(fbas_info, committed.union({split}), remaining_without_split)

--- a/stellarobservatory/quorum_lachowski_test.py
+++ b/stellarobservatory/quorum_lachowski_test.py
@@ -1,5 +1,5 @@
 """Test for Lachowski's quorum intersection function"""
-from .quorum_lachowski import greatest_quorum, has_quorum_intersection, is_quorum, enumerate_quorums
+from .quorum_lachowski import greatest_quorum, has_quorum_intersection, is_quorum
 
 def test_greatest_quorum():
     """Test greatest_quorum()"""
@@ -87,23 +87,3 @@ def test_is_quorum():
     }
     assert is_quorum(slices_by_node, {1, 2}) is True
     assert is_quorum(slices_by_node, {1, 2, 3}) is False
-
-
-def test_enumerate_quorums():
-    """Test enumerate_quorums()"""
-    slices_by_node = {
-        1: [{1, 2, 3, 7}],
-        2: [{1, 2, 3, 7}],
-        3: [{1, 2, 3, 7}],
-        4: [{4, 5, 6, 7}],
-        5: [{4, 5, 6, 7}],
-        6: [{4, 5, 6, 7}],
-        7: [{7}],
-    }
-    quorums = list(enumerate_quorums(slices_by_node))
-    assert set(quorums) == set(
-        [frozenset({7}),
-         frozenset({4, 5, 6, 7}),
-         frozenset({1, 2, 3, 7}),
-         frozenset({1, 2, 3, 4, 5, 6, 7})]
-    )

--- a/stellarobservatory/quorums.py
+++ b/stellarobservatory/quorums.py
@@ -1,0 +1,34 @@
+"""Torstens's quorum enumeration"""
+from .quorum_lachowski import greatest_quorum, next_split_node
+from .quorum_slices import get_dependencies_by_node
+
+
+def enumerate_quorums(slices_by_node):
+    """Enumerate all quorums of FBAS F (given by slices_by_node)."""
+    deps_by_node = get_dependencies_by_node(slices_by_node)
+    fbas_info = {
+        'deps_by_node': deps_by_node,
+        'slices_by_node': slices_by_node
+    }
+    all_nodes = set(slices_by_node.keys())  # all nodes need to be present as keys here
+    return traverse_quorums(fbas_info, set(), all_nodes)
+
+
+def traverse_quorums(fbas_info, committed, remaining):
+    """Given a FBAS F (by fbas_info) with set of nodes V
+    and given the sets: committed ⊆ V; R ⊆ V\\committed,
+    enumerate all quorums Q of F with committed ⊆ Q ⊆ committed ∪ remaining"""
+    perimeter = committed.union(remaining)
+    greatest_q = greatest_quorum(perimeter, fbas_info['slices_by_node'])
+    if greatest_q == set() or not committed.issubset(greatest_q):
+        return
+    yield frozenset(greatest_q)
+
+    current = greatest_q.difference(committed)
+    while not current == set():
+        # v ← pick from W:
+        node = next_split_node(current, fbas_info['deps_by_node'])
+        yield from traverse_quorums(fbas_info,
+                                    greatest_q.difference(current),
+                                    current.difference({node}))
+        current = current.difference({node})

--- a/stellarobservatory/quorums.py
+++ b/stellarobservatory/quorums.py
@@ -7,17 +7,18 @@ from typing import Type
 # Allow for defining an FBAS as a function: (set<T>, T) -> bool.
 # This function returns True, iff the FBAS has a slice for the given node T in the given
 # set.
-FBAS = Callable[[AbstractSet[Type], Type], bool]
+IsSliceContained = Callable[[AbstractSet[Type], Type], bool]
+FBAS = (IsSliceContained, AbstractSet[Type])
 
 
-def enumerate_quorums(is_slice_contained: FBAS, all_nodes):
-    """Enumerate all quorums of FBAS F (given by a function
-    is_slice_contained(set<T>, T) -> bool)."""
+def enumerate_quorums(fbas: FBAS):
+    """Enumerate all quorums of FBAS F (given by the FBAS function(set<T>, T) -> bool)."""
+    (is_slice_contained, all_nodes) = (fbas[0], fbas[1])
     return traverse_quorums(is_slice_contained, set(), all_nodes)
 
 
-def traverse_quorums(is_slice_contained, committed, remaining):
-    """Given a FBAS F (by is_slice_contained) with set of nodes V
+def traverse_quorums(is_slice_contained: IsSliceContained, committed: set, remaining: set):
+    """Given a FBAS F (by fbas) with set of nodes V
     and given the sets: committed ⊆ V; R ⊆ V\\committed,
     enumerate all quorums Q of F with committed ⊆ Q ⊆ committed ∪ remaining"""
     perimeter = committed.union(remaining)
@@ -40,7 +41,7 @@ def traverse_quorums(is_slice_contained, committed, remaining):
         current = current.difference({node})
 
 
-def greatest_quorum(is_slice_contained, nodes):
+def greatest_quorum(is_slice_contained: IsSliceContained, nodes: set):
     """
     Return greatest quorum contained in nodes or empty set (if there is no such quorum).
     """

--- a/stellarobservatory/quorums.py
+++ b/stellarobservatory/quorums.py
@@ -1,34 +1,53 @@
 """Torstens's quorum enumeration"""
-from .quorum_lachowski import greatest_quorum, next_split_node
-from .quorum_slices import get_dependencies_by_node
 
 
-def enumerate_quorums(slices_by_node):
-    """Enumerate all quorums of FBAS F (given by slices_by_node)."""
-    deps_by_node = get_dependencies_by_node(slices_by_node)
-    fbas_info = {
-        'deps_by_node': deps_by_node,
-        'slices_by_node': slices_by_node
-    }
-    all_nodes = set(slices_by_node.keys())  # all nodes need to be present as keys here
-    return traverse_quorums(fbas_info, set(), all_nodes)
+from typing import Callable
+from typing import AbstractSet
+from typing import Type
+
+# Allow for defining an FBAS as a function: (set<T>, T) -> bool.
+# This function returns True, iff the FBAS has a slice for the given node T in the given
+# set.
+FBAS = Callable[[AbstractSet[Type], Type], bool]
+
+def enumerate_quorums(fbas: FBAS, all_nodes):
+    """Enumerate all quorums of FBAS F (given by the FBAS function(set<T>, T) -> bool)."""
+    return traverse_quorums(fbas, set(), all_nodes)
 
 
-def traverse_quorums(fbas_info, committed, remaining):
+def traverse_quorums(fbas, committed, remaining):
     """Given a FBAS F (by fbas_info) with set of nodes V
     and given the sets: committed ⊆ V; R ⊆ V\\committed,
     enumerate all quorums Q of F with committed ⊆ Q ⊆ committed ∪ remaining"""
     perimeter = committed.union(remaining)
-    greatest_q = greatest_quorum(perimeter, fbas_info['slices_by_node'])
+    greatest_q = greatest_quorum(fbas, perimeter)
     if greatest_q == set() or not committed.issubset(greatest_q):
         return
     yield frozenset(greatest_q)
 
     current = greatest_q.difference(committed)
     while not current == set():
-        # v ← pick from W:
-        node = next_split_node(current, fbas_info['deps_by_node'])
-        yield from traverse_quorums(fbas_info,
+        # v ← pick from W = current
+        # (note pylint complains:
+        # Do not raise StopIteration in generator, use return statement instead
+        # but this can't happen as current != set())
+        # pylint: disable=R1708
+        node = next(iter(current))
+        yield from traverse_quorums(fbas,
                                     greatest_q.difference(current),
                                     current.difference({node}))
         current = current.difference({node})
+
+
+def greatest_quorum(fbas, nodes):
+    """
+    Return greatest quorum contained in nodes or empty set (if there is no such quorum).
+    """
+    while True:
+        next_u = set()
+        for node in nodes:
+            if fbas(nodes, node):
+                next_u.add(node)
+        if len(nodes) == len(next_u):
+            return next_u
+        nodes = next_u

--- a/stellarobservatory/quorums.py
+++ b/stellarobservatory/quorums.py
@@ -13,7 +13,7 @@ FBAS = (IsSliceContained, AbstractSet[Type])
 
 def enumerate_quorums(fbas: FBAS):
     """Enumerate all quorums of FBAS F (given by the FBAS function(set<T>, T) -> bool)."""
-    (is_slice_contained, all_nodes) = (fbas[0], fbas[1])
+    (is_slice_contained, all_nodes) = fbas
     return traverse_quorums(is_slice_contained, set(), all_nodes)
 
 

--- a/stellarobservatory/quorums.py
+++ b/stellarobservatory/quorums.py
@@ -12,13 +12,13 @@ FBAS = (IsSliceContained, AbstractSet[Type])
 
 
 def enumerate_quorums(fbas: FBAS):
-    """Enumerate all quorums of FBAS F (given by the FBAS function(set<T>, T) -> bool)."""
+    """Enumerate all quorums of FBAS F (given by the pair (function(set<T>, T) -> bool, set))."""
     (is_slice_contained, all_nodes) = fbas
     return traverse_quorums(is_slice_contained, set(), all_nodes)
 
 
 def traverse_quorums(is_slice_contained: IsSliceContained, committed: set, remaining: set):
-    """Given a FBAS F (by fbas) with set of nodes V
+    """Given a FBAS F (by is_slice_contained) with set of nodes V
     and given the sets: committed ⊆ V; R ⊆ V\\committed,
     enumerate all quorums Q of F with committed ⊆ Q ⊆ committed ∪ remaining"""
     perimeter = committed.union(remaining)

--- a/stellarobservatory/quorums_test.py
+++ b/stellarobservatory/quorums_test.py
@@ -1,0 +1,21 @@
+"""Test for Torstens's quorum enumeration"""
+from .quorums import enumerate_quorums
+
+def test_enumerate_quorums():
+    """Test enumerate_quorums()"""
+    slices_by_node = {
+        1: [{1, 2, 3, 7}],
+        2: [{1, 2, 3, 7}],
+        3: [{1, 2, 3, 7}],
+        4: [{4, 5, 6, 7}],
+        5: [{4, 5, 6, 7}],
+        6: [{4, 5, 6, 7}],
+        7: [{7}],
+    }
+    quorums = list(enumerate_quorums(slices_by_node))
+    assert set(quorums) == set(
+        [frozenset({7}),
+         frozenset({4, 5, 6, 7}),
+         frozenset({1, 2, 3, 7}),
+         frozenset({1, 2, 3, 4, 5, 6, 7})]
+    )

--- a/stellarobservatory/quorums_test.py
+++ b/stellarobservatory/quorums_test.py
@@ -17,7 +17,7 @@ def test_enumerate_quorums():
     def ex28_fbas(nodes_subset, node) -> bool:
         return contains_slice(nodes_subset, slices_by_node, node)
 
-    quorums = list(enumerate_quorums(ex28_fbas, {1, 2, 3, 4, 5, 6, 7}))
+    quorums = list(enumerate_quorums((ex28_fbas, {1, 2, 3, 4, 5, 6, 7})))
     assert set(quorums) == set(
         [frozenset({7}),
          frozenset({4, 5, 6, 7}),
@@ -56,5 +56,5 @@ def test_enumerate_quorums_stellar_core():
                 sufficient_orgs += 1
         return sufficient_orgs >= threshold
 
-    quorums = list(enumerate_quorums(stellar_core, stellar_core_nodes))
+    quorums = list(enumerate_quorums((stellar_core, stellar_core_nodes)))
     assert len(quorums) == 114688

--- a/stellarobservatory/quorums_test.py
+++ b/stellarobservatory/quorums_test.py
@@ -1,8 +1,9 @@
 """Test for Torstens's quorum enumeration"""
 from .quorums import enumerate_quorums
+from .quorum_lachowski import contains_slice
 
 def test_enumerate_quorums():
-    """Test enumerate_quorums()"""
+    """Test enumerate_quorums() with simple example"""
     slices_by_node = {
         1: [{1, 2, 3, 7}],
         2: [{1, 2, 3, 7}],
@@ -12,10 +13,49 @@ def test_enumerate_quorums():
         6: [{4, 5, 6, 7}],
         7: [{7}],
     }
-    quorums = list(enumerate_quorums(slices_by_node))
+
+    def ex28_fbas(nodes_subset, node) -> bool:
+        return contains_slice(nodes_subset, slices_by_node, node)
+
+    quorums = list(enumerate_quorums(ex28_fbas, {1, 2, 3, 4, 5, 6, 7}))
     assert set(quorums) == set(
         [frozenset({7}),
          frozenset({4, 5, 6, 7}),
          frozenset({1, 2, 3, 7}),
          frozenset({1, 2, 3, 4, 5, 6, 7})]
     )
+
+def test_enumerate_quorums_stellar_core():
+    """Test enumerate_quorums() with stellar core style fbas"""
+    # init test:
+    stellar_core_orgs = [
+        {'name': "B", 'nodes': ["1", "2", "3"], 'limit': 2},
+        {'name': "A", 'nodes': ["1", "2", "3"], 'limit': 2},
+        {'name': "C", 'nodes': ["1", "2", "3"], 'limit': 2},
+        {'name': "D", 'nodes': ["1", "2", "3"], 'limit': 2},
+        {'name': "E", 'nodes': ["1", "2", "3"], 'limit': 2},
+        {'name': "F", 'nodes': ["1", "2", "3", "4", "5"], 'limit': 3}
+    ]
+    stellar_core_nodes = set()
+    for org in stellar_core_orgs:
+        name, nodes = org['name'], org['nodes']
+        for node in nodes:
+            stellar_core_nodes.add(name + node)
+
+    def stellar_core(subset: set, _: str) -> bool:
+        sufficient_orgs = 0
+        for org in stellar_core_orgs:
+            name, nodes, limit = org['name'], org['nodes'], org['limit']
+            sufficient_nodes = 0
+            for org_node in nodes:
+                node = str(name + org_node)
+                if node in subset:
+                    sufficient_nodes += 1
+            if sufficient_nodes >= limit:
+                sufficient_orgs += 1
+        return sufficient_orgs >= 5
+
+
+    #logging.debug("all nodes len: %s", stellar_core_nodes)
+    quorums = list(enumerate_quorums(stellar_core, stellar_core_nodes))
+    assert len(quorums) == 114688

--- a/stellarobservatory/quorums_test.py
+++ b/stellarobservatory/quorums_test.py
@@ -42,6 +42,7 @@ def test_enumerate_quorums_stellar_core():
         for node in nodes:
             stellar_core_nodes.add(name + node)
 
+    threshold = 5
     def stellar_core(subset: set, _: str) -> bool:
         sufficient_orgs = 0
         for org in stellar_core_orgs:
@@ -53,9 +54,7 @@ def test_enumerate_quorums_stellar_core():
                     sufficient_nodes += 1
             if sufficient_nodes >= limit:
                 sufficient_orgs += 1
-        return sufficient_orgs >= 5
+        return sufficient_orgs >= threshold
 
-
-    #logging.debug("all nodes len: %s", stellar_core_nodes)
     quorums = list(enumerate_quorums(stellar_core, stellar_core_nodes))
     assert len(quorums) == 114688


### PR DESCRIPTION
replace methods in `quorum_lachowski` with new module `quorums` containing `enumerate_quorums` and `traverse_quorums`

simplified and (hopefully much) faster version of https://github.com/andrenarchy/stellar-observatory/pull/5